### PR TITLE
bin/magic: Make it work with file 5.22

### DIFF
--- a/bin/magic
+++ b/bin/magic
@@ -271,7 +271,7 @@
 >9	string	\0
 >>0	string	KWAJ
 >>>7	string	\321\003	MS Compress archive data
->>>>14	ulong	>0		\b, original size: %ld bytes
+>>>>14	ulong	>0		\b, original size: %u bytes
 >>>>18		ubyte	>0x65
 >>>>>18		string	x       \b, was %.8s
 >>>>>(10.b-4)	string	x       \b.%.3s
@@ -876,7 +876,7 @@
 # From: Dirk Jagdmann <doj@cubic.org>
 # xar archive format: http://code.google.com/p/xar/
 0	string	xar!		xar archive
->6	beshort	x		- version %ld
+>6	beshort	x		- version %d
 
 # From: "Nelson A. de Oliveira" <naoliv@gmail.com>
 # .kgb


### PR DESCRIPTION
This used to contain to printf() style strings that did not work
they way they are supposed to work.

This fixes #1

Signed-off-by: Julian Andres Klode <jak@jak-linux.org>